### PR TITLE
Gewählte Technologie wird falschem Agenten zugewiesen

### DIFF
--- a/helpers.R
+++ b/helpers.R
@@ -153,7 +153,7 @@ run_simulation <- function(interaction_id, n_agents, n_techs,
                                intrinsic_utilities = intrinsic_utilities,
                                choice_mode=choose_mode)
     network_used <- set_vertex_attr(
-      network_used, "technology", index = v, value = chosen_tech)
+      network_used, "technology", index = agents_sequence[v], value = chosen_tech)
     current_rel_freqs <- prop.table(table(factor(V(network_used)$technology, 
                                                  levels = levels(all_techs))))
     for (t in all_techs){


### PR DESCRIPTION
choose_tech wählt in Zeile 151 die Technologie für den zufälligen Agenten agents_sequence[v]. In Zeile 156 wird die gewählte Technologie dann fälschlicherweise dem Agenten v und nicht dem Agenten  agents_sequence[v] zugewiesen.