### PR TITLE
Zufällige Zuweisung der Präferenzen

### DIFF
--- a/helpers.R
+++ b/helpers.R
@@ -59,7 +59,7 @@ create_network <- function(n_agents, n_techs, topology){
                                   index = V(network_used), NA)
   
   agents_per_group <- n_agents / n_techs
-  groups <- Hmisc::partition.vector(V(network_used), rep(agents_per_group, n_techs))
+  groups <- Hmisc::partition.vector(sample(V(network_used)), rep(agents_per_group, n_techs))
   for (i in 1:length(names(groups))){
     network_used <- set_vertex_attr(network_used, "preferred_tech", 
                                     index = groups[[names(groups)[i]]], 


### PR DESCRIPTION
Insbesondere beim Ring-Netzwerk führt die Zuweisung der präferierten Technologie dazu, dass Nachbarn fast immer die gleichen Präferenzen haben (bei 2 Technologien präferiert die erste Hälfte T1, die zweite T2). sample(V(network_used)) führt zu einer zufälligen Zuweisung der Präferenzen. In Kombination mit der falschen Zuweisung der gewählten Technologie des Agenten in Zeile 156 (siehe anderer pull request) führt die nicht zufällige Zuweisung dazu, dass die Technologie 1 auch bei ausgeglichenen Präferenzen immer seltener als T2 gewählt wird.